### PR TITLE
Clean Install Scripts

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -1,9 +1,0 @@
-#!/system/bin/sh
-# Do NOT assume where your module will be located.
-# ALWAYS use $MODDIR if you need to know where this script
-# and module is placed.
-# This will make sure your module will still work
-# if Magisk change its mount point in the future
-MODDIR=${0%/*}
-
-# This script will be executed in post-fs-data mode

--- a/common/service.sh
+++ b/common/service.sh
@@ -1,9 +1,0 @@
-#!/system/bin/sh
-# Do NOT assume where your module will be located.
-# ALWAYS use $MODDIR if you need to know where this script
-# and module is placed.
-# This will make sure your module will still work
-# if Magisk change its mount point in the future
-MODDIR=${0%/*}
-
-# This script will be executed in late_start service mode

--- a/common/system.prop
+++ b/common/system.prop
@@ -1,3 +1,0 @@
-# This file will be read by resetprop
-# Example: Change dpi
-# ro.sf.lcd_density=320


### PR DESCRIPTION
Remove unused scripts according to [Magisk Developer Guides](https://topjohnwu.github.io/Magisk/guides.html#magisk-modules).

Testing passed on:
MiPad 1, Lineage OS 16.0, Magisk 21.1 with Magisk Manager 8.0.3
RedMi K20 Pro, MIUI 12.0.5, Magisk 21.1 with Magisk Manager 8.0.3